### PR TITLE
Add indexOf debugging support

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,5 @@
+---
+IndentWidth: 4
+UseTab: Never
+ColumnLimit: 120
+AlignAfterOpenBracket: AlwaysBreak

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,8 @@ add_library(${PROJECT_NAME} SHARED
     "src/ConfusableMatcher/Config.h"
     "src/ConfusableMatcher/Shared.h"
     "src/ConfusableMatcher/ConfusableMatcherData.cpp"
+    "src/ConfusableMatcher/Debugging.h"
+    "src/ConfusableMatcher/MatchingState.h"
     ${CMAKE_JS_SRC}
 )
 target_link_libraries(${PROJECT_NAME} ${CMAKE_JS_LIB} ${CMAKE_THREAD_LIBS_INIT})

--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ This library exports a wrapper class bundled with TypeScript declarations that a
         -   [2.1.17. lastIndexOf(input, needle, options): Promise<IResult>](#2117-lastindexofinput-needle-options-promiseiresult)
         -   [2.1.18. containsSync(input, needle, options): boolean](#2118-containssyncinput-needle-options-boolean)
         -   [2.1.19. contains(input, needle, options?): Promise<boolean>](#2119-containsinput-needle-options-promiseboolean)
+        -   [2.1.20. indexOfDebugFailuresSync(input, needle, options?): string[]](#2120-indexofdebugfailuressyncinput-needle-options-string)
+        -   [2.1.21. indexOfDebugFailures(input, needle, options?): Promise<string[]>](#2121-indexofdebugfailuresinput-needle-options-promisestring)
+        -   [2.1.22. indexOfDebugFailuresExSync(input, needle, options?): IDebugFailureResult](#2122-indexofdebugfailuresexsyncinput-needle-options-idebugfailureresult)
+        -   [2.1.23. indexOfDebugFailuresEx(input, needle, options?): Promise<IDebugFailureResult>](#2123-indexofdebugfailuresexinput-needle-options-promiseidebugfailureresult)
 -   [3. Development](#3-development)
     -   [3.1. Testing](#31-testing)
     -   [3.2. Benchmarks](#32-benchmarks)
@@ -303,6 +307,58 @@ containsSync(input: string, needle: string, options?: IIndexOfOptions): boolean
  * @returns A Promise that resolves to true if the `needle` is found inside `input`.
  */
 contains(input: string, needle: string, options?: IIndexOfOptions): Promise<boolean>
+```
+
+#### 2.1.20. indexOfDebugFailuresSync(input, needle, options?): string[]
+
+```ts
+/**
+ * @description Searches for the first occurrence of `needle` in `input` with debugging enabled.
+ * @param input The string to search.
+ * @param needle The string to look for in `input`.
+ * @param options An optional object containing options in the search.
+ * @returns An array of strings containing failure debugging reasons.
+ */
+indexOfDebugFailuresSync(input: string, needle: string, options?: Partial<IIndexOfOptions>): string[]
+```
+
+#### 2.1.21. indexOfDebugFailures(input, needle, options?): Promise<string[]>
+
+```ts
+/**
+ * @description Searches for the first occurrence of `needle` in `input` with debugging enabled.
+ * @param input The string to search.
+ * @param needle The string to look for in `input`.
+ * @param options An optional object containing options in the search.
+ * @returns An array of strings containing failure debugging reasons.
+ */
+indexOfDebugFailures(input: string, needle: string, options?: Partial<IIndexOfOptions>): Promise<string[]>
+```
+
+#### 2.1.22. indexOfDebugFailuresExSync(input, needle, options?): IDebugFailureResult
+
+```ts
+/**
+ * @description Searches for the first occurrence of `needle` in `input` with debugging enabled.
+ * @param input The string to search.
+ * @param needle The string to look for in `input`.
+ * @param options An optional object containing options in the search.
+ * @returns An object containing match information.
+ */
+indexOfDebugFailuresExSync(input: string, needle: string, options?: Partial<IIndexOfOptions>): IDebugFailureResult
+```
+
+#### 2.1.23. indexOfDebugFailuresEx(input, needle, options?): Promise<IDebugFailureResult>
+
+```ts
+/**
+ * @description Searches for the first occurrence of `needle` in `input` with debugging enabled.
+ * @param input The string to search.
+ * @param needle The string to look for in `input`.
+ * @param options An optional object containing options in the search.
+ * @returns A Promise that resolves to an object containing match information.
+ */
+indexOfDebugFailuresEx(input: string, needle: string, options?: Partial<IIndexOfOptions>): Promise<IDebugFailureResult>
 ```
 
 ## 3. Development

--- a/src/benchmark/benchs/indexOfDebugFailures.ts
+++ b/src/benchmark/benchs/indexOfDebugFailures.ts
@@ -1,0 +1,16 @@
+import type Benchmark from 'benchmark';
+
+import type { ConfusableMatcher } from '../../wrapper';
+import type { ConfigureFn } from '../bench';
+
+export const configure: ConfigureFn = (suite: Benchmark.Suite, cm: ConfusableMatcher) => {
+    suite.add(
+        'ConfusableMatcher#indexOfDebugFailures',
+        (defer: Benchmark.Deferred) => {
+            cm.indexOfDebugFailures('SIMP', 'SINP', { matchOnWordBoundary: true, matchRepeating: true }).finally(() =>
+                defer.resolve()
+            );
+        },
+        { defer: true }
+    );
+};

--- a/src/benchmark/benchs/indexOfDebugFailuresEx.ts
+++ b/src/benchmark/benchs/indexOfDebugFailuresEx.ts
@@ -1,0 +1,16 @@
+import type Benchmark from 'benchmark';
+
+import type { ConfusableMatcher } from '../../wrapper';
+import type { ConfigureFn } from '../bench';
+
+export const configure: ConfigureFn = (suite: Benchmark.Suite, cm: ConfusableMatcher) => {
+    suite.add(
+        'ConfusableMatcher#indexOfDebugFailuresEx',
+        (defer: Benchmark.Deferred) => {
+            cm.indexOfDebugFailuresEx('SIMP', 'SINP', { matchOnWordBoundary: true, matchRepeating: true }).finally(() =>
+                defer.resolve()
+            );
+        },
+        { defer: true }
+    );
+};

--- a/src/benchmark/benchs/indexOfDebugFailuresExSync.ts
+++ b/src/benchmark/benchs/indexOfDebugFailuresExSync.ts
@@ -1,0 +1,10 @@
+import type Benchmark from 'benchmark';
+
+import type { ConfusableMatcher } from '../../wrapper';
+import type { ConfigureFn } from '../bench';
+
+export const configure: ConfigureFn = (suite: Benchmark.Suite, cm: ConfusableMatcher) => {
+    suite.add('ConfusableMatcher#indexOfDebugFailuresExSync', () =>
+        cm.indexOfDebugFailuresExSync('SIMP', 'SINP', { matchOnWordBoundary: true, matchRepeating: true })
+    );
+};

--- a/src/benchmark/benchs/indexOfDebugFailuresSync.ts
+++ b/src/benchmark/benchs/indexOfDebugFailuresSync.ts
@@ -1,0 +1,10 @@
+import type Benchmark from 'benchmark';
+
+import type { ConfusableMatcher } from '../../wrapper';
+import type { ConfigureFn } from '../bench';
+
+export const configure: ConfigureFn = (suite: Benchmark.Suite, cm: ConfusableMatcher) => {
+    suite.add('ConfusableMatcher#indexOfDebugFailuresSync', () =>
+        cm.indexOfDebugFailuresSync('SIMP', 'SINP', { matchOnWordBoundary: true, matchRepeating: true })
+    );
+};

--- a/src/benchmark/index.ts
+++ b/src/benchmark/index.ts
@@ -3,6 +3,10 @@ import Benchmark from 'benchmark';
 
 import { ConfusableMatcher } from '../';
 import * as indexOf from './benchs/indexOf';
+import * as indexOfDebugFailures from './benchs/indexOfDebugFailures';
+import * as indexOfDebugFailuresEx from './benchs/indexOfDebugFailuresEx';
+import * as indexOfDebugFailuresExSync from './benchs/indexOfDebugFailuresExSync';
+import * as indexOfDebugFailuresSync from './benchs/indexOfDebugFailuresSync';
 import * as indexOfStrPosPointers from './benchs/indexOfStrPosPointers';
 import * as indexOfSync from './benchs/indexOfSync';
 import * as indexOfSyncStrPosPointers from './benchs/indexOfSyncStrPosPointers';
@@ -26,6 +30,10 @@ const matcher = new ConfusableMatcher();
     indexOfStrPosPointers.configure,
     indexOfSync.configure,
     indexOfSyncStrPosPointers.configure,
+    indexOfDebugFailures.configure,
+    indexOfDebugFailuresEx.configure,
+    indexOfDebugFailuresExSync.configure,
+    indexOfDebugFailuresSync.configure,
 ].forEach((fn) => fn(suite, matcher));
 console.log('Running benchmark...');
 suite.run({ async: true });

--- a/src/binding.ts
+++ b/src/binding.ts
@@ -14,6 +14,25 @@ export interface IResult {
     status: EReturnStatus;
 }
 
+export enum EDebugFailureReason {
+    NO_PATH = 0,
+    NO_NEW_PATHS = 1,
+    TIMEOUT = 2,
+    WORD_BOUNDARY_FAIL_START = 3,
+    WORD_BOUNDARY_FAIL_END = 4,
+}
+
+export interface IDebugFailure {
+    inPos: number;
+    containsPos: number;
+    reason: EDebugFailureReason;
+}
+
+export interface IDebugFailureResult {
+    result: IResult;
+    failures: IDebugFailure[];
+}
+
 export interface IIndexOfOptions {
     matchRepeating: boolean;
     startIndex: number;
@@ -32,6 +51,13 @@ export declare class ConfusableMatcherInstance {
     freeStringPosPointers(pointer: StrPosPointer): void;
     indexOf(input: string, needle: string, options?: IIndexOfOptions): IResult;
     indexOfAsync(callback: (result: IResult) => void, input: string, needle: string, options?: IIndexOfOptions): void;
+    indexOfDebugFailures(input: string, needle: string, options?: IIndexOfOptions): IDebugFailureResult;
+    indexOfDebugFailuresAsync(
+        callback: (result: IDebugFailureResult) => void,
+        input: string,
+        needle: string,
+        options?: IIndexOfOptions
+    ): void;
 }
 
 interface IConfusableMatcherProptotype {

--- a/src/indexOfAsyncWorker.cpp
+++ b/src/indexOfAsyncWorker.cpp
@@ -1,0 +1,22 @@
+#include "indexOfAsyncWorker.h"
+
+ConfusableMatcherIndexOfAsyncWorker::ConfusableMatcherIndexOfAsyncWorker(
+    Napi::Function &callback, ConfusableMatcher *cm, std::string in, std::string needle, CMOptions opts)
+    : Napi::AsyncWorker(callback) {
+    this->_cm = cm;
+    this->_in = in;
+    this->_needle = needle;
+    this->_opts = opts;
+};
+
+void ConfusableMatcherIndexOfAsyncWorker::Execute() {
+    this->result = this->_cm->IndexOf(this->_in, this->_needle, this->_opts);
+};
+
+void ConfusableMatcherIndexOfAsyncWorker::OnOK() {
+    Napi::Object obj = Napi::Object::New(Env());
+    obj.Set(Napi::String::New(this->Env(), "size"), Napi::Number::New(this->Env(), this->result.Size));
+    obj.Set(Napi::String::New(this->Env(), "start"), Napi::Number::New(this->Env(), this->result.Start));
+    obj.Set(Napi::String::New(this->Env(), "status"), Napi::Number::New(this->Env(), this->result.Status));
+    this->Callback().Call({obj});
+};

--- a/src/indexOfAsyncWorker.h
+++ b/src/indexOfAsyncWorker.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <napi.h>
+#include "ConfusableMatcher/ConfusableMatcher.h"
+
+class ConfusableMatcherIndexOfAsyncWorker : public Napi::AsyncWorker
+{
+public:
+    ConfusableMatcherIndexOfAsyncWorker(Napi::Function &callback, ConfusableMatcher *cm, std::string in, std::string needle, CMOptions opts);
+    virtual ~ConfusableMatcherIndexOfAsyncWorker(){};
+
+    void Execute() override;
+    void OnOK() override;
+
+    CMReturn result;
+
+private:
+    ConfusableMatcher *_cm;
+    std::string _in;
+    std::string _needle;
+    CMOptions _opts;
+};

--- a/src/indexOfDebugFailuresAsyncWorker.cpp
+++ b/src/indexOfDebugFailuresAsyncWorker.cpp
@@ -1,0 +1,44 @@
+#include "indexOfDebugFailuresAsyncWorker.h"
+
+ConfusableMatcherIndexOfDebugFailuresAsyncWorker::ConfusableMatcherIndexOfDebugFailuresAsyncWorker(
+    Napi::Function &callback, ConfusableMatcher *cm, std::string in, std::string needle, CMOptions opts)
+    : Napi::AsyncWorker(callback) {
+    this->_cm = cm;
+    this->_in = in;
+    this->_needle = needle;
+    this->_opts = opts;
+};
+
+void ConfusableMatcherIndexOfDebugFailuresAsyncWorker::Execute() {
+    this->result = this->_cm->IndexOfDebugFailures(this->_in, this->_needle, this->_opts, &this->failures);
+};
+
+void ConfusableMatcherIndexOfDebugFailuresAsyncWorker::OnOK() {
+    Napi::Env env = Env();
+
+    Napi::Object result = Napi::Object::New(env);
+    result.Set(Napi::String::New(env, "size"), Napi::Number::New(env, this->result.Size));
+    result.Set(Napi::String::New(env, "start"), Napi::Number::New(env, this->result.Start));
+    result.Set(Napi::String::New(env, "status"), Napi::Number::New(env, this->result.Status));
+
+    size_t size = this->failures.size();
+    Napi::Object failures = Napi::Array::New(Env());
+    for (size_t x = 0; x < size; x++) {
+        uint64_t inPos = this->failures[x].InPos;
+        uint64_t containsPos = this->failures[x].ContainsPos;
+        CM_DEBUG_FAILURE_REASON reason = this->failures[x].Reason;
+
+        Napi::Object failure = Napi::Object::New(Env());
+        failure.Set(Napi::String::New(this->Env(), "inPos"), Napi::Number::New(this->Env(), inPos));
+        failure.Set(Napi::String::New(this->Env(), "containsPos"), Napi::Number::New(this->Env(), containsPos));
+        failure.Set(Napi::String::New(this->Env(), "reason"), Napi::Number::New(this->Env(), reason));
+
+        failures[x] = failure;
+    }
+
+    Napi::Object value = Napi::Object::New(Env());
+    value.Set(Napi::String::New(this->Env(), "result"), result);
+    value.Set(Napi::String::New(this->Env(), "failures"), failures);
+
+    this->Callback().Call({value});
+};

--- a/src/indexOfDebugFailuresAsyncWorker.h
+++ b/src/indexOfDebugFailuresAsyncWorker.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "ConfusableMatcher/ConfusableMatcher.h"
+#include <napi.h>
+
+class ConfusableMatcherIndexOfDebugFailuresAsyncWorker : public Napi::AsyncWorker {
+  public:
+    ConfusableMatcherIndexOfDebugFailuresAsyncWorker(
+        Napi::Function &callback, ConfusableMatcher *cm, std::string in, std::string needle, CMOptions opts);
+    virtual ~ConfusableMatcherIndexOfDebugFailuresAsyncWorker(){};
+
+    void Execute() override;
+    void OnOK() override;
+
+    CMReturn result;
+    std::vector<CMDebugFailure> failures;
+
+  private:
+    ConfusableMatcher *_cm;
+    std::string _in;
+    std::string _needle;
+    CMOptions _opts;
+};

--- a/src/interop.cpp
+++ b/src/interop.cpp
@@ -1,69 +1,37 @@
 #include "interop.h"
+#include "indexOfAsyncWorker.h"
+#include "indexOfDebugFailuresAsyncWorker.h"
 
-ConfusableMatcherIndexOfAsyncWorker::ConfusableMatcherIndexOfAsyncWorker(Napi::Function &callback, ConfusableMatcher *cm, std::string in, std::string needle, CMOptions opts)
-    : Napi::AsyncWorker(callback)
-{
-    this->_cm = cm;
-    this->_in = in;
-    this->_needle = needle;
-    this->_opts = opts;
-};
-
-void ConfusableMatcherIndexOfAsyncWorker::Execute()
-{
-    this->result = this->_cm->IndexOf(this->_in, this->_needle, this->_opts);
-};
-
-void ConfusableMatcherIndexOfAsyncWorker::OnOK()
-{
-    Napi::Object obj = Napi::Object::New(Env());
-    obj.Set(Napi::String::New(this->Env(), "size"), Napi::Number::New(this->Env(), this->result.Size));
-    obj.Set(Napi::String::New(this->Env(), "start"), Napi::Number::New(this->Env(), this->result.Start));
-    obj.Set(Napi::String::New(this->Env(), "status"), Napi::Number::New(this->Env(), this->result.Status));
-    this->Callback().Call({obj});
-};
-
-ConfusableMatcherNapiInterop::ConfusableMatcherNapiInterop(const Napi::CallbackInfo &info) : ObjectWrap(info)
-{
+ConfusableMatcherNapiInterop::ConfusableMatcherNapiInterop(const Napi::CallbackInfo &info) : ObjectWrap(info) {
     Napi::Env env = info.Env();
 
     std::vector<std::pair<std::string, std::string>> mapVector;
     Napi::Array mapArray = info[0].As<Napi::Array>();
-    for (uint32_t x = 0; x < mapArray.Length(); x++)
-    {
+    for (uint32_t x = 0; x < mapArray.Length(); x++) {
         Napi::Array result = mapArray.Get(x).As<Napi::Array>();
         std::pair<std::string, std::string> kvPair = {
-            result.Get((uint32_t)0).ToString().Utf8Value(),
-            result.Get((uint32_t)1).ToString().Utf8Value()};
+            result.Get((uint32_t)0).ToString().Utf8Value(), result.Get((uint32_t)1).ToString().Utf8Value()};
         mapVector.push_back(kvPair);
     }
 
     std::unordered_set<std::string> skipsSet;
     Napi::Array skipsArray = info[1].As<Napi::Array>();
-    for (uint32_t x = 0; x < skipsArray.Length(); x++)
-    {
+    for (uint32_t x = 0; x < skipsArray.Length(); x++) {
         skipsSet.insert(skipsArray.Get(x).ToString().Utf8Value());
     }
 
     bool addDefaults = info[2].ToBoolean();
 
-    try
-    {
+    try {
         this->_instance = new ConfusableMatcher(mapVector, skipsSet, addDefaults);
-    }
-    catch (const std::runtime_error &error)
-    {
+    } catch (const std::runtime_error &error) {
         throw Napi::Error::New(env, error.what());
     }
 }
 
-ConfusableMatcherNapiInterop::~ConfusableMatcherNapiInterop()
-{
-    delete this->_instance;
-}
+ConfusableMatcherNapiInterop::~ConfusableMatcherNapiInterop() { delete this->_instance; }
 
-Napi::Value ConfusableMatcherNapiInterop::getKeyMappings(const Napi::CallbackInfo &info)
-{
+Napi::Value ConfusableMatcherNapiInterop::getKeyMappings(const Napi::CallbackInfo &info) {
     Napi::Env env = info.Env();
     std::string key = info[0].ToString().Utf8Value();
 
@@ -72,24 +40,21 @@ Napi::Value ConfusableMatcherNapiInterop::getKeyMappings(const Napi::CallbackInf
 
     size_t size = mappings.Size();
     Napi::Array result = Napi::Array::New(env, size);
-    for (size_t x = 0; x < size; x++)
-    {
+    for (size_t x = 0; x < size; x++) {
         result[x] = Napi::String::New(env, mappings.GetElement(x).Str);
     }
 
     return result;
 }
 
-Napi::Value ConfusableMatcherNapiInterop::computeStringPosPointers(const Napi::CallbackInfo &info)
-{
+Napi::Value ConfusableMatcherNapiInterop::computeStringPosPointers(const Napi::CallbackInfo &info) {
     Napi::Env env = info.Env();
     std::string needle = info[0].ToString().Utf8Value();
     CMStringPosPointers *stringPosPointer = this->_instance->ComputeStringPosPointers(needle);
     return Napi::External<CMStringPosPointers>::New(info.Env(), stringPosPointer);
 }
 
-Napi::Value ConfusableMatcherNapiInterop::freeStringPosPointers(const Napi::CallbackInfo &info)
-{
+Napi::Value ConfusableMatcherNapiInterop::freeStringPosPointers(const Napi::CallbackInfo &info) {
     Napi::Env env = info.Env();
     Napi::External<CMStringPosPointers> external = info[0].As<Napi::External<CMStringPosPointers>>();
     CMStringPosPointers *stringPosPointer = external.Data();
@@ -97,8 +62,7 @@ Napi::Value ConfusableMatcherNapiInterop::freeStringPosPointers(const Napi::Call
     return env.Undefined();
 }
 
-Napi::Value ConfusableMatcherNapiInterop::indexOf(const Napi::CallbackInfo &info)
-{
+Napi::Value ConfusableMatcherNapiInterop::indexOf(const Napi::CallbackInfo &info) {
     Napi::Env env = info.Env();
 
     std::string in = info[0].ToString().Utf8Value();
@@ -113,8 +77,7 @@ Napi::Value ConfusableMatcherNapiInterop::indexOf(const Napi::CallbackInfo &info
     cmOpts.MatchOnWordBoundary = optionsObject.Get("matchOnWordBoundary").ToBoolean();
 
     auto posPointer = optionsObject.Get("needlePosPointers");
-    if (!posPointer.IsNull())
-    {
+    if (!posPointer.IsNull()) {
         Napi::External<CMStringPosPointers> external = posPointer.As<Napi::External<CMStringPosPointers>>();
         CMStringPosPointers *stringPosPointer = external.Data();
         cmOpts.ContainsPosPointers = stringPosPointer;
@@ -130,8 +93,7 @@ Napi::Value ConfusableMatcherNapiInterop::indexOf(const Napi::CallbackInfo &info
     return obj;
 }
 
-Napi::Value ConfusableMatcherNapiInterop::indexOfAsync(const Napi::CallbackInfo &info)
-{
+Napi::Value ConfusableMatcherNapiInterop::indexOfAsync(const Napi::CallbackInfo &info) {
     Napi::Env env = info.Env();
 
     Napi::Function callback = info[0].As<Napi::Function>();
@@ -147,37 +109,118 @@ Napi::Value ConfusableMatcherNapiInterop::indexOfAsync(const Napi::CallbackInfo 
     cmOpts.MatchOnWordBoundary = optionsObject.Get("matchOnWordBoundary").ToBoolean();
 
     auto posPointer = optionsObject.Get("needlePosPointers");
-    if (!posPointer.IsNull())
-    {
+    if (!posPointer.IsNull()) {
         Napi::External<CMStringPosPointers> external = posPointer.As<Napi::External<CMStringPosPointers>>();
         CMStringPosPointers *stringPosPointer = external.Data();
         cmOpts.ContainsPosPointers = stringPosPointer;
     }
 
-    ConfusableMatcherIndexOfAsyncWorker *worker = new ConfusableMatcherIndexOfAsyncWorker(callback, this->_instance, in, needle, cmOpts);
+    ConfusableMatcherIndexOfAsyncWorker *worker =
+        new ConfusableMatcherIndexOfAsyncWorker(callback, this->_instance, in, needle, cmOpts);
     worker->Queue();
     return env.Undefined();
 };
 
-Napi::Function ConfusableMatcherNapiInterop::GetClass(Napi::Env env)
-{
+Napi::Value ConfusableMatcherNapiInterop::indexOfDebugFailures(const Napi::CallbackInfo &info) {
+    Napi::Env env = info.Env();
+
+    std::string in = info[0].ToString().Utf8Value();
+    std::string needle = info[1].ToString().Utf8Value();
+    Napi::Object optionsObject = info[2].As<Napi::Object>();
+
+    CMOptions cmOpts = {};
+    cmOpts.MatchRepeating = optionsObject.Get("matchRepeating").ToBoolean();
+    cmOpts.StartIndex = optionsObject.Get("startIndex").ToNumber().Uint32Value();
+    cmOpts.StartFromEnd = optionsObject.Get("startFromEnd").ToBoolean();
+    cmOpts.TimeoutNs = optionsObject.Get("timeoutNs").ToNumber().Uint32Value();
+    cmOpts.MatchOnWordBoundary = optionsObject.Get("matchOnWordBoundary").ToBoolean();
+
+    auto posPointer = optionsObject.Get("needlePosPointers");
+    if (!posPointer.IsNull()) {
+        Napi::External<CMStringPosPointers> external = posPointer.As<Napi::External<CMStringPosPointers>>();
+        CMStringPosPointers *stringPosPointer = external.Data();
+        cmOpts.ContainsPosPointers = stringPosPointer;
+    }
+
+    std::vector<CMDebugFailure> rawFailures;
+    CMReturn rawResult = this->_instance->IndexOfDebugFailures(in, needle, cmOpts, &rawFailures);
+
+    Napi::Object result = Napi::Object::New(Env());
+    result.Set(Napi::String::New(env, "size"), Napi::Number::New(env, rawResult.Size));
+    result.Set(Napi::String::New(env, "start"), Napi::Number::New(env, rawResult.Start));
+    result.Set(Napi::String::New(env, "status"), Napi::Number::New(env, rawResult.Status));
+
+    size_t size = rawFailures.size();
+    Napi::Object failures = Napi::Array::New(Env());
+    for (size_t x = 0; x < size; x++) {
+        uint64_t inPos = rawFailures[x].InPos;
+        uint64_t containsPos = rawFailures[x].ContainsPos;
+        CM_DEBUG_FAILURE_REASON reason = rawFailures[x].Reason;
+
+        Napi::Object failure = Napi::Object::New(Env());
+        failure.Set(Napi::String::New(this->Env(), "inPos"), Napi::Number::New(this->Env(), inPos));
+        failure.Set(Napi::String::New(this->Env(), "containsPos"), Napi::Number::New(this->Env(), containsPos));
+        failure.Set(Napi::String::New(this->Env(), "reason"), Napi::Number::New(this->Env(), reason));
+
+        failures[x] = failure;
+    }
+
+    Napi::Object value = Napi::Object::New(Env());
+    value.Set(Napi::String::New(this->Env(), "result"), result);
+    value.Set(Napi::String::New(this->Env(), "failures"), failures);
+
+    return value;
+}
+
+Napi::Value ConfusableMatcherNapiInterop::indexOfDebugFailuresAsync(const Napi::CallbackInfo &info) {
+    Napi::Env env = info.Env();
+
+    Napi::Function callback = info[0].As<Napi::Function>();
+    std::string in = info[1].ToString().Utf8Value();
+    std::string needle = info[2].ToString().Utf8Value();
+    Napi::Object optionsObject = info[3].As<Napi::Object>();
+
+    CMOptions cmOpts = {};
+    cmOpts.MatchRepeating = optionsObject.Get("matchRepeating").ToBoolean();
+    cmOpts.StartIndex = optionsObject.Get("startIndex").ToNumber().Uint32Value();
+    cmOpts.StartFromEnd = optionsObject.Get("startFromEnd").ToBoolean();
+    cmOpts.TimeoutNs = optionsObject.Get("timeoutNs").ToNumber().Uint32Value();
+    cmOpts.MatchOnWordBoundary = optionsObject.Get("matchOnWordBoundary").ToBoolean();
+
+    auto posPointer = optionsObject.Get("needlePosPointers");
+    if (!posPointer.IsNull()) {
+        Napi::External<CMStringPosPointers> external = posPointer.As<Napi::External<CMStringPosPointers>>();
+        CMStringPosPointers *stringPosPointer = external.Data();
+        cmOpts.ContainsPosPointers = stringPosPointer;
+    }
+
+    ConfusableMatcherIndexOfDebugFailuresAsyncWorker *worker =
+        new ConfusableMatcherIndexOfDebugFailuresAsyncWorker(callback, this->_instance, in, needle, cmOpts);
+    worker->Queue();
+    return env.Undefined();
+};
+
+Napi::Function ConfusableMatcherNapiInterop::GetClass(Napi::Env env) {
     return DefineClass(
-        env,
-        "ConfusableMatcher",
+        env, "ConfusableMatcher",
         {
-            ConfusableMatcherNapiInterop::InstanceMethod("getKeyMappings", &ConfusableMatcherNapiInterop::getKeyMappings),
-            ConfusableMatcherNapiInterop::InstanceMethod("computeStringPosPointers", &ConfusableMatcherNapiInterop::computeStringPosPointers),
-            ConfusableMatcherNapiInterop::InstanceMethod("freeStringPosPointers", &ConfusableMatcherNapiInterop::freeStringPosPointers),
+            ConfusableMatcherNapiInterop::InstanceMethod(
+                "getKeyMappings", &ConfusableMatcherNapiInterop::getKeyMappings),
+            ConfusableMatcherNapiInterop::InstanceMethod(
+                "computeStringPosPointers", &ConfusableMatcherNapiInterop::computeStringPosPointers),
+            ConfusableMatcherNapiInterop::InstanceMethod(
+                "freeStringPosPointers", &ConfusableMatcherNapiInterop::freeStringPosPointers),
             ConfusableMatcherNapiInterop::InstanceMethod("indexOf", &ConfusableMatcherNapiInterop::indexOf),
             ConfusableMatcherNapiInterop::InstanceMethod("indexOfAsync", &ConfusableMatcherNapiInterop::indexOfAsync),
+            ConfusableMatcherNapiInterop::InstanceMethod(
+                "indexOfDebugFailures", &ConfusableMatcherNapiInterop::indexOfDebugFailures),
+            ConfusableMatcherNapiInterop::InstanceMethod(
+                "indexOfDebugFailuresAsync", &ConfusableMatcherNapiInterop::indexOfDebugFailuresAsync),
         });
 }
 
-Napi::Object Init(Napi::Env env, Napi::Object exports)
-{
-    exports.Set(
-        Napi::String::New(env, "ConfusableMatcher"),
-        ConfusableMatcherNapiInterop::GetClass(env));
+Napi::Object Init(Napi::Env env, Napi::Object exports) {
+    exports.Set(Napi::String::New(env, "ConfusableMatcher"), ConfusableMatcherNapiInterop::GetClass(env));
     return exports;
 }
 

--- a/src/interop.h
+++ b/src/interop.h
@@ -1,11 +1,10 @@
 #pragma once
 
-#include <napi.h>
 #include "ConfusableMatcher/ConfusableMatcher.h"
+#include <napi.h>
 
-class ConfusableMatcherNapiInterop : public Napi::ObjectWrap<ConfusableMatcherNapiInterop>
-{
-public:
+class ConfusableMatcherNapiInterop : public Napi::ObjectWrap<ConfusableMatcherNapiInterop> {
+  public:
     ConfusableMatcherNapiInterop(const Napi::CallbackInfo &);
     ~ConfusableMatcherNapiInterop();
 
@@ -14,27 +13,11 @@ public:
     Napi::Value freeStringPosPointers(const Napi::CallbackInfo &);
     Napi::Value indexOf(const Napi::CallbackInfo &);
     Napi::Value indexOfAsync(const Napi::CallbackInfo &);
+    Napi::Value indexOfDebugFailures(const Napi::CallbackInfo &);
+    Napi::Value indexOfDebugFailuresAsync(const Napi::CallbackInfo &);
 
     static Napi::Function GetClass(Napi::Env);
 
-private:
+  private:
     ConfusableMatcher *_instance;
-};
-
-class ConfusableMatcherIndexOfAsyncWorker : public Napi::AsyncWorker
-{
-public:
-    ConfusableMatcherIndexOfAsyncWorker(Napi::Function &callback, ConfusableMatcher *cm, std::string in, std::string needle, CMOptions opts);
-    virtual ~ConfusableMatcherIndexOfAsyncWorker(){};
-
-    void Execute() override;
-    void OnOK() override;
-
-    CMReturn result;
-
-private:
-    ConfusableMatcher *_cm;
-    std::string _in;
-    std::string _needle;
-    CMOptions _opts;
 };

--- a/src/wrapper.spec.ts
+++ b/src/wrapper.spec.ts
@@ -1,6 +1,6 @@
 /* cSpell: disable */
 import type { IIndexOfOptions, Mapping } from './binding';
-import { EReturnStatus } from './binding';
+import { EDebugFailureReason, EReturnStatus } from './binding';
 import { ConfusableMatcher } from './wrapper';
 
 describe('Unit Tests', () => {
@@ -954,6 +954,66 @@ describe('Unit Tests', () => {
             expect(r.start).toEqual(1);
             expect(r.size).toEqual(8);
             m.freeStringPosPointers(needlePtr);
+        });
+    });
+
+    describe('Debug', () => {
+        it('Should produce debug matches', () => {
+            const opts: Partial<IIndexOfOptions> = {
+                matchOnWordBoundary: true,
+                matchRepeating: true,
+            };
+            const map: Mapping[] = [
+                ['N', '/B/'],
+                ['I', '/'],
+            ];
+            const m = new ConfusableMatcher(map, []);
+            const input = 'I/B/AM';
+            const needle = 'INAN';
+            const { failures } = m.indexOfDebugFailuresExSync(input, needle, opts);
+
+            let x = 0;
+            expect(failures[x].inPos).toEqual(5);
+            expect(failures[x].containsPos).toEqual(3);
+            expect(failures[x++].reason).toEqual(EDebugFailureReason.NO_NEW_PATHS);
+
+            expect(failures[x].inPos).toEqual(2);
+            expect(failures[x].containsPos).toEqual(1);
+            expect(failures[x++].reason).toEqual(EDebugFailureReason.NO_PATH);
+
+            expect(failures[x].inPos).toEqual(2);
+            expect(failures[x].containsPos).toEqual(1);
+            expect(failures[x++].reason).toEqual(EDebugFailureReason.NO_PATH);
+
+            expect(failures[x].inPos).toEqual(4);
+            expect(failures[x].containsPos).toEqual(1);
+            expect(failures[x++].reason).toEqual(EDebugFailureReason.NO_PATH);
+
+            expect(failures[x].inPos).toEqual(6);
+            expect(failures[x].containsPos).toEqual(0);
+            expect(failures[x++].reason).toEqual(EDebugFailureReason.NO_PATH);
+        });
+
+        it('Should produce failure debug strings', () => {
+            const opts: Partial<IIndexOfOptions> = {
+                matchOnWordBoundary: true,
+                matchRepeating: true,
+            };
+            const map: Mapping[] = [
+                ['N', '/B/'],
+                ['I', '/'],
+            ];
+            const m = new ConfusableMatcher(map, []);
+            const input = 'I/B/AM';
+            const needle = 'INAN';
+            const failures = m.indexOfDebugFailuresSync(input, needle, opts);
+
+            let x = 0;
+            expect('No new paths in input /AM̲ (5) comparing NAN̲ (3)').toEqual(failures[x++]);
+            expect('No path in input I/B̲/AM (2) comparing IN̲AN (1)').toEqual(failures[x++]);
+            expect('No path in input I/B̲/AM (2) comparing IN̲AN (1)').toEqual(failures[x++]);
+            expect('No path in input B/A̲M (4) comparing IN̲AN (1)').toEqual(failures[x++]);
+            expect('No path in input /AM ̲ (6) comparing I̲NAN (0)').toEqual(failures[x++]);
         });
     });
 });


### PR DESCRIPTION
## Changes

Please make a summary of the changes made:

- Adds four new methods to help implementors debug confusable matches:
    - indexOfDebugFailuresExSync - Exclusively returns failure and match information to build your own failure reasons.
    - indexOfDebugFailuresEx - Async version of `indexOfDebugFailuresExSync`.
    - indexOfDebugFailuresSync - Returns an array of failure reasons for the `input`, `needle` and `options` specified.
    - indexOfDebugFailures - Async version of `indexOfDebugFailuresSync`.
    
Unit tests have been replicated from the [.NET interop library](https://github.com/TETYYS/ConfusableMatcher-cs-interop).

This upgrades to https://github.com/TETYYS/ConfusableMatcher/commit/29b3ddf609ba37f910f87a4ed68e3bafcf3e0122 as a strict dependency.